### PR TITLE
Fix/llm payload and UI fix

### DIFF
--- a/src/components/Assessment.tsx
+++ b/src/components/Assessment.tsx
@@ -266,7 +266,6 @@ const Assessment = ({
   // PDF generation state
   const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
   const [showDetailedViewer, setShowDetailedViewer] = useState(false);
-  const [showPillarViewer, setShowPillarViewer] = useState(false);
   const [pdfError, setPdfError] = useState<string | null>(null);
 
   const mockAssessmentResults: AssessmentResults = {
@@ -2375,15 +2374,6 @@ const Assessment = ({
                     Available Actions
                   </h3>
                   <div className="flex flex-wrap gap-3">
-                    {webhookData && (
-                      <button
-                        onClick={() => setShowPillarViewer(true)}
-                        className="flex items-center bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
-                      >
-                        <MagnifyingGlassIcon className="w-4 h-4 mr-2" />
-                        View Detailed Pillar Data
-                      </button>
-                    )}
                     {hasAssessmentResults && (
                       <>
                         <button
@@ -2420,15 +2410,6 @@ const Assessment = ({
                     Technical Remediation Plan
                   </h2>
                   <div className="flex items-center space-x-3">
-                    {webhookData && (
-                      <button
-                        onClick={() => setShowPillarViewer(true)}
-                        className="flex items-center bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
-                      >
-                        <MagnifyingGlassIcon className="w-4 h-4 mr-2" />
-                        View Pillar Data
-                      </button>
-                    )}
                     {hasAssessmentResults && (
                       <>
                         <button
@@ -2648,32 +2629,6 @@ const Assessment = ({
           </div>
         )}
         
-        {/* Pillar Data Viewer Modal */}
-        {showPillarViewer && webhookData && (
-          <div className="fixed inset-0 z-50 overflow-y-auto">
-            <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-              {/* Background overlay */}
-              <div 
-                className="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75"
-                onClick={() => setShowPillarViewer(false)}
-              />
-              
-              {/* Modal content */}
-              <div className="inline-block w-full max-w-6xl px-4 pt-5 pb-4 overflow-hidden text-left align-bottom transition-all transform bg-white rounded-lg shadow-xl sm:my-8 sm:align-middle sm:p-6">
-                <div className="flex justify-between items-center mb-4">
-                  <h2 className="text-2xl font-bold">Accounting Quality Pillar Data</h2>
-                  <button
-                    onClick={() => setShowPillarViewer(false)}
-                    className="text-gray-400 hover:text-gray-600 transition-colors"
-                  >
-                    <CrossCircledIcon className="w-6 h-6" />
-                  </button>
-                </div>
-                {/* Raw data viewer removed - data shown in tables */}
-              </div>
-            </div>
-          </div>
-        )}
         
         {/* Detailed Assessment Viewer Modal */}
         {showDetailedViewer && assessmentResults && (

--- a/src/services/llm/ClaudeAdapter.ts
+++ b/src/services/llm/ClaudeAdapter.ts
@@ -95,7 +95,10 @@ export class ClaudeAdapter extends BaseLLMService {
       headers: {
         "x-api-key": this.config.apiKey,
         "anthropic-version": this.apiVersion,
+<<<<<<< HEAD
         "anthropic-dangerous-direct-browser-access": "true",
+=======
+>>>>>>> cb55593 (fix DOM rendition for EULA. adds adapters to llm apis viz perplexity and claude)
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -348,7 +351,10 @@ export class ClaudeAdapter extends BaseLLMService {
         headers: {
           "x-api-key": this.config.apiKey,
           "anthropic-version": this.apiVersion,
+<<<<<<< HEAD
           "anthropic-dangerous-direct-browser-access": "true",
+=======
+>>>>>>> cb55593 (fix DOM rendition for EULA. adds adapters to llm apis viz perplexity and claude)
           "Content-Type": "application/json",
         },
         body: JSON.stringify({

--- a/src/services/llm/ClaudeAdapter.ts
+++ b/src/services/llm/ClaudeAdapter.ts
@@ -6,7 +6,6 @@
 import { BaseLLMService } from "./BaseLLMService";
 import { LLMProvider, LLMMessage, LLMResponse, LLMConfig } from "./types";
 import { logger } from "@/lib/logger";
-import { LLMInputFormatter } from "../llmInputFormatter";
 
 export class ClaudeAdapter extends BaseLLMService {
   private readonly API_BASE_URL: string;
@@ -95,10 +94,7 @@ export class ClaudeAdapter extends BaseLLMService {
       headers: {
         "x-api-key": this.config.apiKey,
         "anthropic-version": this.apiVersion,
-<<<<<<< HEAD
         "anthropic-dangerous-direct-browser-access": "true",
-=======
->>>>>>> cb55593 (fix DOM rendition for EULA. adds adapters to llm apis viz perplexity and claude)
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -146,14 +142,8 @@ export class ClaudeAdapter extends BaseLLMService {
       // Load assessment prompt
       const systemPrompt = await this.loadAssessmentPrompt();
 
-      // Format the raw QBO data for LLM input
-      const inputData = {
-        webhookData: rawData,
-        calculatedAssessment: null,
-        formattedDate: new Date().toISOString(),
-        companyName: rawData.meta?.companyName || "Unknown Company",
-      };
-      const formattedData = LLMInputFormatter.formatForLLM(inputData);
+      // Send raw QBO data directly to LLM without any formatting
+      const formattedData = JSON.stringify(rawData);
 
       logger.debug(
         `Formatted data size: ${formattedData.length} chars, estimated tokens: ${this.estimateTokens(formattedData)}`,
@@ -351,10 +341,7 @@ export class ClaudeAdapter extends BaseLLMService {
         headers: {
           "x-api-key": this.config.apiKey,
           "anthropic-version": this.apiVersion,
-<<<<<<< HEAD
           "anthropic-dangerous-direct-browser-access": "true",
-=======
->>>>>>> cb55593 (fix DOM rendition for EULA. adds adapters to llm apis viz perplexity and claude)
           "Content-Type": "application/json",
         },
         body: JSON.stringify({

--- a/src/services/llm/PerplexityAdapter.ts
+++ b/src/services/llm/PerplexityAdapter.ts
@@ -6,7 +6,6 @@
 import { BaseLLMService } from "./BaseLLMService";
 import { LLMProvider, LLMMessage, LLMResponse, LLMConfig } from "./types";
 import { logger } from "@/lib/logger";
-import { LLMInputFormatter } from "../llmInputFormatter";
 
 export class PerplexityAdapter extends BaseLLMService {
   private readonly API_BASE_URL = "https://api.perplexity.ai";
@@ -120,14 +119,8 @@ export class PerplexityAdapter extends BaseLLMService {
       // Load assessment prompt
       const systemPrompt = await this.loadAssessmentPrompt();
 
-      // Format the raw QBO data for LLM input
-      const inputData = {
-        webhookData: rawData,
-        calculatedAssessment: null,
-        formattedDate: new Date().toISOString(),
-        companyName: rawData.meta?.companyName || "Unknown Company",
-      };
-      const formattedData = LLMInputFormatter.formatForLLM(inputData);
+      // Send raw QBO data directly to LLM without any formatting
+      const formattedData = JSON.stringify(rawData);
 
       // Create messages for API
       const messages: LLMMessage[] = [


### PR DESCRIPTION
fix: correct LLM payload format and remove pillar viewer

      - Send raw QBO data directly to LLMs without formatting
      - Remove calculatedAssessment field from API payloads
      - Remove View Pillar Data button and modal from UI
      - Clean up unused showPillarViewer state variable

      Fixes incorrect use of LLMInputFormatter in API calls.
      LLMs now receive unmodified QuickBooks data as intended.